### PR TITLE
Cache .mypy_cache in CI to speed up linting.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,14 @@ jobs:
         key: venv-ci-${{ matrix.os }}-${{ runner.arch }}-${{ steps.python-version.outputs.version }}-${{ hashFiles('poetry.lock') }}
         path: .venv
 
+    - name: Cache mypy cache
+      uses: actions/cache@v2
+      with:
+        # Don't need to be so careful here,
+        #   https://github.com/python/mypy/issues/10221#issuecomment-801330908
+        key: mypy-cache-ci-${{ runner.os }}-${{ matrix.python-version }}
+        path: .mypy_cache
+
     - name: Install dependencies
       run: |
         poetry install


### PR DESCRIPTION
Cache the .mypy_cache folder in CI to speed up the linting step.