### PR TITLE
Add Python 3.11 to CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 
@@ -81,7 +81,7 @@ jobs:
 
       - uses: actions/setup-python@v4.2.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install coverage
         run: python -m pip install coverage[toml]


### PR DESCRIPTION
mypy 0.990 [added](https://mypy-lang.blogspot.com/2022/11/mypy-0990-released.html) basic 3.11 support. We're still working on 3.9, so the lack of 3.11 language feature support in mypy _shouldn't_ be an issue.