### PR TITLE
Remove deprecated set-output in GitHub Actions yaml.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Get Tox env
       id: tox-env
       run: |
-        echo ::set-output name=env::$(echo py${{ matrix.python-version }} | tr -d .)
+        echo env=$(echo py${{ matrix.python-version }} | tr -d .) >> $GITHUB_OUTPUT
 
     - name: Cache mypy cache
       uses: actions/cache@v3.0.9


### PR DESCRIPTION
The set-output command has been deprecated; should now use the $GITHUB_OUTPUT env var file [[1]].

[1]: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/