### PR TITLE
Fixes for tox4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install poetry
-      run: pipx install poetry==1.1.13
+      run: pipx install poetry==1.2.2
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install poetry
-      run: pipx install poetry==1.2.2
+      run: pipx install poetry==1.3.1
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Run tests
       # We only want to *see* test results in this step, not coverage info.
       run: |
-        poetry run tox -e ${{ steps.tox-env.outputs.env }} -- --cov --cov-config=pyproject.toml --cov-report=
+        poetry run -- tox run -e ${{ steps.tox-env.outputs.env }} -- --cov --cov-config=pyproject.toml --cov-report=
 
     - name: Upload coverage data for Python ${{ matrix.python-version }}
       uses: actions/upload-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,14 @@ lint:
 
 .PHONY: test
 test:
-	poetry run tox -q --skip-missing-interpreters=true
+	poetry run -- tox run -q --skip-missing-interpreters=true
 
 .PHONY: coverage
 coverage:
-	-poetry run tox -q --skip-missing-interpreters=true -- -q --cov --cov-config=pyproject.toml --cov-report=
-	poetry run tox -q -e coverage -- combine
-	poetry run tox -q -e coverage -- html
-	poetry run tox -q -e coverage -- report
+	-poetry run -- tox run -q --skip-missing-interpreters=true -- -q --cov --cov-config=pyproject.toml --cov-report=
+	poetry run -- tox run -q -e coverage -- combine
+	poetry run -- tox run -q -e coverage -- html
+	poetry run -- tox run -q -e coverage -- report
 
 .PHONY: update
 update:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Python implementation of the Lox language
 
 ## Developer Quickstart
 
-[`poetry`][poetry] is a dependency.
+[`poetry`][poetry]>=1.2 is a dependency.
 
 Install this package and its dependencies,
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ skip_empty = true
 [tool.coverage.paths]
 source = [
     "src/plox/",
-    ".tox/*/site-packages/plox/"
+    ".tox*/*/lib/python*/site-packages/plox",
 ]
 
 [tool.isort]

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ isolated_build = True
 envlist =
     py39
     py310
+    py311
 
 [testenv]
 deps =


### PR DESCRIPTION
### Local

tox4 requires a `--` to separate arguments to tox from those of the command it runs. We always had this, but (at least for the `Makefile` invocation), this seems to interfere with/be interfered with when tox is invoked with `poetry run`, as poetry run also uses `--` to separate arguments.

It seems that running via `make` is an issue specifically, as directly shell (zsh) invocations of lines from the `Makefile` did in fact work as expected. That's probably why it was working fine in CI.

This also adds the 'run' command to tox invocations, rather than letting it default to the legacy entrypoint.

(Discovered this while trying to diagnose the build failures due to the coverage step failing...)

### CI

The paths tox stores its managed environments at has changed. We need to update the source mappings for `coverage` so it can related code in `src/plox/...` to the files coverage is _actually_ generated from (`.tox/...`)