### PR TITLE
Remove deprecated dev-dependencies from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "GNU Affero General Public License"
 [tool.poetry.dependencies]
 python = "^3.9"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "^22.12.0"
 pre-commit = "^2.21.0"
 flake8 = "^6.0.0"


### PR DESCRIPTION
Dependency groups were added in poetry 1.2.